### PR TITLE
Updated CipherSuites...

### DIFF
--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -486,7 +486,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('system', 'mod_fcgid_defaultini_ownvhost', '2'),
 	('system', 'awstats_icons', '/usr/share/awstats/icon/'),
 	('system', 'ssl_cert_chainfile', ''),
-	('system', 'ssl_cipher_list', 'ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128'),
+	('system', 'ssl_cipher_list', 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH'),
 	('system', 'nginx_php_backend', '127.0.0.1:8888'),
 	('system', 'perl_server', 'unix:/var/run/nginx/cgiwrap-dispatch.sock'),
 	('system', 'phpreload_command', ''),


### PR DESCRIPTION
... due to incompatibility between Server <-> Java

With the current set of Suites, Java returns: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure

I've updated the Suite as suggested by https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html (scroll down to "The Cipher Suite").

This results to: https://www.ssllabs.com/ssltest/analyze.html?d=git.kluthr.de and enables Java-Clients (NetBeans in my case ;) ) to connect again.

The old suite seems to be stronger but makes Java-Clients unable to connect. Maybe someone have better solutions for this.